### PR TITLE
Added the possibility to read configurations from the Slicer.ini file…

### DIFF
--- a/LumpNav/LumpNav.py
+++ b/LumpNav/LumpNav.py
@@ -60,6 +60,7 @@ class LumpNavWidget(GuideletWidget):
     settings = slicer.app.userSettings() 
     settings.beginGroup(self.moduleName + '/Configurations/Default')
     if not settings.allKeys(): # If no keys     
+      settings.setValue('EnableBreachWarningLight', 'True')
       settings.setValue('TipToSurfaceDistanceCrossHair', 'True')
       settings.setValue('TipToSurfaceDistanceText', 'True')
       settings.setValue('TipToSurfaceDistanceTrajectory', 'True')
@@ -106,7 +107,7 @@ class LumpNavWidget(GuideletWidget):
     else:
         self.breachWarningLightCheckBox.setEnabled(True)
         settings = slicer.app.userSettings()
-        lightEnabled = settings.value(self.moduleName+'/EnableBreachWarningLight', 'True')
+        lightEnabled = settings.value(self.moduleName + '/Configurations/' + self.selectedConfigurationName + '/EnableBreachWarningLight', 'True')
         self.breachWarningLightCheckBox.checked = (lightEnabled == 'True')
         self.launcherFormLayout.addWidget(self.breachWarningLightCheckBox)
   
@@ -121,7 +122,7 @@ class LumpNavWidget(GuideletWidget):
         if parameterlist!=None:
           parameterlist['EnableBreachWarningLight'] = lightEnabled
         settings = slicer.app.userSettings()
-        settings.setValue(self.moduleName + '/EnableBreachWarningLight', lightEnabled)
+        settings.setValue(self.moduleName + '/Configurations/' + self.selectedConfigurationName + '/EnableBreachWarningLight', lightEnabled)
 
     # Configuration   
     settings = slicer.app.userSettings() 

--- a/LumpNav/LumpNav.py
+++ b/LumpNav/LumpNav.py
@@ -46,15 +46,15 @@ class LumpNavWidget(GuideletWidget):
     
     GuideletWidget.setup(self)
     
-  def addLauncherWidgets(self):
+  def addLauncherWidgets(self):  
     GuideletWidget.addLauncherWidgets(self)
-
+    
     # Configurations
     self.addConfigurationsSelector()
     
     # BreachWarning
     self.breachWarningLight()  
- 
+    
   # Adds a default configurations to Slicer.ini
   def addDefaultConfiguration(self):
     settings = slicer.app.userSettings() 
@@ -72,7 +72,12 @@ class LumpNavWidget(GuideletWidget):
   # Adds a list box populated with the available configurations in the Slicer.ini file
   def addConfigurationsSelector(self):
     self.configurationsComboBox = qt.QComboBox()
-    self.launcherFormLayout.addRow('Select Configuration: ', self.configurationsComboBox)
+    configurationsLabel = qt.QLabel("Select Configuration: ")
+    hBox = qt.QHBoxLayout()
+    hBox.addWidget(configurationsLabel)
+    hBox.addWidget(self.configurationsComboBox)    
+    hBox.setStretch(1,2)
+    self.launcherFormLayout.addRow(hBox)
     
     # Populate configurationsComboBox with available configurations
     settings = slicer.app.userSettings() 
@@ -97,7 +102,7 @@ class LumpNavWidget(GuideletWidget):
     checkBoxLabel.setText("Use Breach Warning Light: ")
     hBoxCheck.addWidget(checkBoxLabel)
     hBoxCheck.addWidget(self.breachWarningLightCheckBox)
-
+    hBoxCheck.setStretch(1,2)
     self.launcherFormLayout.addRow(hBoxCheck)
 
     if(lnNode is not None and lnNode.GetParameter('EnableBreachWarningLight')):
@@ -109,7 +114,6 @@ class LumpNavWidget(GuideletWidget):
         settings = slicer.app.userSettings()
         lightEnabled = settings.value(self.moduleName + '/Configurations/' + self.selectedConfigurationName + '/EnableBreachWarningLight', 'True')
         self.breachWarningLightCheckBox.checked = (lightEnabled == 'True')
-        self.launcherFormLayout.addWidget(self.breachWarningLightCheckBox)
   
   def collectParameterList(self):
     parameterlist = GuideletWidget.collectParameterList(self)


### PR DESCRIPTION
…. There is a Select Configuration ComboBox in the launcher widget which is populated by the available configurations in Slicer.ini. A default configuration is added automatically (and this default configuration should probably have more parameters). Depending on which configuration the user chose, the paramters from this configuration will be read into the widget parameter list. Also the two transforms CauteryModelToCauteryTip and needleModelToNeedleTip are now read from this configuration, as well as written to it.

As a test, you can add the following lines to LumpNav in the Slicer.ini file:

Configurations\madrid\TipToSurfaceDistanceCrossHair=True
Configurations\madrid\TipToSurfaceDistanceText=True
Configurations\madrid\TipToSurfaceDistanceTrajectory=True
Configurations\madrid\needleModelToNeedleTip=0 0 1 0 0 -1 0 0 1 0 0 0 0 0 0 1
Configurations\madrid\cauteryModelToCauteryTip=0 0 1 0 0 -1 0 0 1 0 0 0 0 0 0 1

Then you should be able to chose between two configurations (default and madrid). Depending on which one you chose the needle model will have different orientation.
